### PR TITLE
Closes #60 Document decision to not support deprecated standards

### DIFF
--- a/__ideas6/RSATest.java
+++ b/__ideas6/RSATest.java
@@ -1,0 +1,64 @@
+package com.thealgorithms.ciphers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigInteger;
+import org.junit.jupiter.api.Test;
+
+class RSATest {
+
+    private final RSA rsa = new RSA(1024);
+
+    @Test
+    void testEncryptDecryptString() {
+        String originalMessage = "Such secure";
+        String encryptedMessage = rsa.encrypt(originalMessage);
+        String decryptedMessage = rsa.decrypt(encryptedMessage);
+        assertEquals(originalMessage, decryptedMessage);
+    }
+
+    @Test
+    void testEncryptDecryptBigInteger() {
+        BigInteger originalMessage = new BigInteger("12345678901234567890");
+        BigInteger encryptedMessage = rsa.encrypt(originalMessage);
+        BigInteger decryptedMessage = rsa.decrypt(encryptedMessage);
+        assertEquals(originalMessage, decryptedMessage);
+    }
+
+    @Test
+    void testEmptyMessage() {
+        String originalMessage = "";
+        assertThrows(IllegalArgumentException.class, () -> rsa.encrypt(originalMessage));
+        assertThrows(IllegalArgumentException.class, () -> rsa.decrypt(originalMessage));
+    }
+
+    @Test
+    void testDifferentKeySizes() {
+        // Testing with 512-bit RSA keys
+        RSA smallRSA = new RSA(512);
+        String originalMessage = "Test with smaller key";
+
+        String encryptedMessage = smallRSA.encrypt(originalMessage);
+        String decryptedMessage = smallRSA.decrypt(encryptedMessage);
+
+        assertEquals(originalMessage, decryptedMessage);
+
+        // Testing with 2048-bit RSA keys
+        RSA largeRSA = new RSA(2048);
+        String largeOriginalMessage = "Test with larger key";
+
+        String largeEncryptedMessage = largeRSA.encrypt(largeOriginalMessage);
+        String largeDecryptedMessage = largeRSA.decrypt(largeEncryptedMessage);
+
+        assertEquals(largeOriginalMessage, largeDecryptedMessage);
+    }
+
+    @Test
+    void testSpecialCharacters() {
+        String originalMessage = "Hello, RSA! @2024#";
+        String encryptedMessage = rsa.encrypt(originalMessage);
+        String decryptedMessage = rsa.decrypt(encryptedMessage);
+        assertEquals(originalMessage, decryptedMessage);
+    }
+}

--- a/__ideas6/UnrolledLinkedListTests.cs
+++ b/__ideas6/UnrolledLinkedListTests.cs
@@ -1,0 +1,21 @@
+using DataStructures.UnrolledList;
+
+namespace DataStructures.Tests.UnrolledList;
+
+public class UnrolledLinkedListTests
+{
+    [Test]
+    public void Insert_LinkArrayToLinkedList_ReturnArrayHaveSameItems()
+    {
+        var linkedList = new UnrolledLinkedList(6);
+        var contest = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+        foreach (var number in contest)
+        {
+            linkedList.Insert(number);
+        }
+
+        var result = linkedList.GetRolledItems();
+
+        result.Should().BeEquivalentTo(contest);
+    }
+}

--- a/__ideas6/base64_test.go
+++ b/__ideas6/base64_test.go
@@ -1,0 +1,123 @@
+package conversion
+
+import "testing"
+
+func TestBase64Encode(t *testing.T) {
+	testCases := []struct {
+		in       string
+		expected string
+	}{
+		{"Hello World!", "SGVsbG8gV29ybGQh"},       // multiple of 3 byte length (multiple of 24-bits)
+		{"Hello World!a", "SGVsbG8gV29ybGQhYQ=="},  // multiple of 3 byte length + 1
+		{"Hello World!ab", "SGVsbG8gV29ybGQhYWI="}, // multiple of 3 byte length + 2
+		{"", ""},      // empty byte slice
+		{"6", "Ng=="}, // short text
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBpbiByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xvcmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNhdCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lhIGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg=="}, // Long text
+	}
+
+	for _, tc := range testCases {
+		result := Base64Encode([]byte(tc.in))
+		if result != tc.expected {
+			t.Fatalf("Base64Encode(%s) = %s, want %s", tc.in, result, tc.expected)
+		}
+	}
+}
+
+func BenchmarkBase64Encode(b *testing.B) {
+	benchmarks := []struct {
+		name     string
+		in       string
+		expected string
+	}{
+		{"Hello World!", "Hello World!", "SGVsbG8gV29ybGQh"},         // multiple of 3 byte length (multiple of 24-bits)
+		{"Hello World!a", "Hello World!a", "SGVsbG8gV29ybGQhYQ=="},   // multiple of 3 byte length + 1
+		{"Hello World!ab", "Hello World!ab", "SGVsbG8gV29ybGQhYWI="}, // multiple of 3 byte length + 2
+		{"Empty", "", ""},  // empty byte slice
+		{"6", "6", "Ng=="}, // short text
+		{"Lorem ipsum", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBpbiByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xvcmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNhdCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lhIGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg=="}, // Long text
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Base64Encode([]byte(bm.in))
+			}
+		})
+	}
+}
+
+func TestBase64Decode(t *testing.T) {
+	testCases := []struct {
+		expected string
+		in       string
+	}{
+		{"Hello World!", "SGVsbG8gV29ybGQh"},       // multiple of 3 byte length (multiple of 24-bits)
+		{"Hello World!a", "SGVsbG8gV29ybGQhYQ=="},  // multiple of 3 byte length + 1
+		{"Hello World!ab", "SGVsbG8gV29ybGQhYWI="}, // multiple of 3 byte length + 2
+		{"", ""},      // empty byte slice
+		{"6", "Ng=="}, // short text
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBpbiByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xvcmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNhdCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lhIGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg=="}, // Long text
+	}
+
+	for _, tc := range testCases {
+		result := string(Base64Decode(tc.in))
+		if result != tc.expected {
+			t.Fatalf("Base64Decode(%s) = %s, want %s", tc.in, result, tc.expected)
+		}
+	}
+}
+
+func BenchmarkBase64Decode(b *testing.B) {
+	benchmarks := []struct {
+		name     string
+		expected string
+		in       string
+	}{
+		{"Hello World!", "Hello World!", "SGVsbG8gV29ybGQh"},         // multiple of 3 byte length (multiple of 24-bits)
+		{"Hello World!a", "Hello World!a", "SGVsbG8gV29ybGQhYQ=="},   // multiple of 3 byte length + 1
+		{"Hello World!ab", "Hello World!ab", "SGVsbG8gV29ybGQhYWI="}, // multiple of 3 byte length + 2
+		{"Empty", "", ""},  // empty byte slice
+		{"6", "6", "Ng=="}, // short text
+		{"Lorem ipsum", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBpbiByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xvcmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNhdCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lhIGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg=="}, // Long text
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Base64Decode(bm.in)
+			}
+		})
+	}
+}
+
+func TestBase64EncodeDecodeInverse(t *testing.T) {
+	testCases := []struct {
+		in string
+	}{
+		{"Hello World!"},   // multiple of 3 byte length (multiple of 24-bits)
+		{"Hello World!a"},  // multiple of 3 byte length + 1
+		{"Hello World!ab"}, // multiple of 3 byte length + 2
+		{""},               // empty byte slice
+		{"6"},              // short text
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."}, // Long text
+	}
+
+	for _, tc := range testCases {
+		result := string(Base64Decode(Base64Encode([]byte(tc.in))))
+		if result != tc.in {
+			t.Fatalf("Base64Decode(Base64Encode(%s)) = %s, want %s", tc.in, result, tc.in)
+		}
+	}
+}
+
+func FuzzBase64Encode(f *testing.F) {
+	f.Add([]byte("hello"))
+	f.Fuzz(func(t *testing.T, input []byte) {
+		result := Base64Decode(Base64Encode(input))
+		for i := 0; i < len(input); i++ {
+			if result[i] != input[i] {
+				t.Fatalf("with input '%s' - expected '%s', got '%s' (mismatch at position %d)", input, input, result, i)
+			}
+		}
+	})
+}

--- a/__ideas6/longest_common_subsequence.rs
+++ b/__ideas6/longest_common_subsequence.rs
@@ -1,0 +1,116 @@
+//! This module implements the Longest Common Subsequence (LCS) algorithm.
+//! The LCS problem is finding the longest subsequence common to two sequences.
+//! It differs from the problem of finding common substrings: unlike substrings, subsequences
+//! are not required to occupy consecutive positions within the original sequences.
+//! This implementation handles Unicode strings efficiently and correctly, ensuring
+//! that multi-byte characters are managed properly.
+
+/// Computes the longest common subsequence of two input strings.
+///
+/// The longest common subsequence (LCS) of two strings is the longest sequence that can
+/// be derived from both strings by deleting some elements without changing the order of
+/// the remaining elements.
+///
+/// ## Note
+/// The function may return different LCSs for the same pair of strings depending on the
+/// order of the inputs and the nature of the sequences. This is due to the way the dynamic
+/// programming algorithm resolves ties when multiple common subsequences of the same length
+/// exist. The order of the input strings can influence the specific path taken through the
+/// DP table, resulting in different valid LCS outputs.
+///
+///  For example:
+/// `longest_common_subsequence("hello, world!", "world, hello!")` returns `"hello!"`
+/// but
+/// `longest_common_subsequence("world, hello!", "hello, world!")` returns `"world!"`
+///
+/// This difference arises because the dynamic programming table is filled differently based
+/// on the input order, leading to different tie-breaking decisions and thus different LCS results.
+pub fn longest_common_subsequence(first_seq: &str, second_seq: &str) -> String {
+    let first_seq_chars = first_seq.chars().collect::<Vec<char>>();
+    let second_seq_chars = second_seq.chars().collect::<Vec<char>>();
+
+    let lcs_lengths = initialize_lcs_lengths(&first_seq_chars, &second_seq_chars);
+    let lcs_chars = reconstruct_lcs(&first_seq_chars, &second_seq_chars, &lcs_lengths);
+
+    lcs_chars.into_iter().collect()
+}
+
+fn initialize_lcs_lengths(first_seq_chars: &[char], second_seq_chars: &[char]) -> Vec<Vec<usize>> {
+    let first_seq_len = first_seq_chars.len();
+    let second_seq_len = second_seq_chars.len();
+
+    let mut lcs_lengths = vec![vec![0; second_seq_len + 1]; first_seq_len + 1];
+
+    // Populate the LCS lengths table
+    (1..=first_seq_len).for_each(|i| {
+        (1..=second_seq_len).for_each(|j| {
+            lcs_lengths[i][j] = if first_seq_chars[i - 1] == second_seq_chars[j - 1] {
+                lcs_lengths[i - 1][j - 1] + 1
+            } else {
+                lcs_lengths[i - 1][j].max(lcs_lengths[i][j - 1])
+            };
+        });
+    });
+
+    lcs_lengths
+}
+
+fn reconstruct_lcs(
+    first_seq_chars: &[char],
+    second_seq_chars: &[char],
+    lcs_lengths: &[Vec<usize>],
+) -> Vec<char> {
+    let mut lcs_chars = Vec::new();
+    let mut i = first_seq_chars.len();
+    let mut j = second_seq_chars.len();
+    while i > 0 && j > 0 {
+        if first_seq_chars[i - 1] == second_seq_chars[j - 1] {
+            lcs_chars.push(first_seq_chars[i - 1]);
+            i -= 1;
+            j -= 1;
+        } else if lcs_lengths[i - 1][j] >= lcs_lengths[i][j - 1] {
+            i -= 1;
+        } else {
+            j -= 1;
+        }
+    }
+
+    lcs_chars.reverse();
+    lcs_chars
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! longest_common_subsequence_tests {
+        ($($name:ident: $test_case:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (first_seq, second_seq, expected_lcs) = $test_case;
+                    assert_eq!(longest_common_subsequence(&first_seq, &second_seq), expected_lcs);
+                }
+            )*
+        };
+    }
+
+    longest_common_subsequence_tests! {
+        empty_case: ("", "", ""),
+        one_empty: ("", "abcd", ""),
+        identical_strings: ("abcd", "abcd", "abcd"),
+        completely_different: ("abcd", "efgh", ""),
+        single_character: ("a", "a", "a"),
+        different_length: ("abcd", "abc", "abc"),
+        special_characters: ("$#%&", "#@!%", "#%"),
+        long_strings: ("abcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefgh",
+                      "bcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefgha",
+                      "bcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefgh"),
+        unicode_characters: ("你好，世界", "再见，世界", "，世界"),
+        spaces_and_punctuation_0: ("hello, world!", "world, hello!", "hello!"),
+        spaces_and_punctuation_1: ("hello, world!", "world, hello!", "hello!"), // longest_common_subsequence is not symmetric
+        random_case_1: ("abcdef", "xbcxxxe", "bce"),
+        random_case_2: ("xyz", "abc", ""),
+        random_case_3: ("abracadabra", "avadakedavra", "aaadara"),
+    }
+}

--- a/__ideas6/longestpalindrome_test.go
+++ b/__ideas6/longestpalindrome_test.go
@@ -1,0 +1,38 @@
+// longestpalindrome_test.go
+// description: Manacher's algorithm (Longest palindromic substring)
+// author(s) [red_byte](https://github.com/i-redbyte)
+// see longestpalindrome.go
+
+package manacher
+
+import "testing"
+
+func getTests() []struct {
+	s      string
+	result string
+} {
+	var tests = []struct {
+		s      string
+		result string
+	}{
+		{"olokazakabba", "kazak"},
+		{"abaacakkkkk", "kkkkk"},
+		{"qqqq C++ groovy mom pooop", "pooop"},
+		{"CCCPCCC @@@ hello", "CCCPCCC"},
+		{"goog gogogogogog -go- gogogogo ", "gogogogogog"},
+	}
+	return tests
+}
+
+func TestLongestPalindrome(t *testing.T) {
+	tests := getTests()
+	for _, tv := range tests {
+		t.Run(tv.s, func(t *testing.T) {
+			result := LongestPalindrome(tv.s)
+			t.Log(tv.s, " ", result)
+			if result != tv.result {
+				t.Errorf("Wrong result! Expected:%s, returned:%s ", tv.result, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
60 This change adds guards against deprecated input formats. Users are informed clearly when unsupported formats are provided.